### PR TITLE
chore(deps): enable dependabot github-actions grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,16 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      org-actions:
+        applies-to: version-updates
+        patterns: ["Coalfire-CF/*"]
+        update-types: ["minor", "patch"]
+      third-party:
+        applies-to: version-updates
+        patterns: ["*"]
+        exclude-patterns: ["Coalfire-CF/*"]
+        update-types: ["minor", "patch"]
   - package-ecosystem: "terraform"
     directory: "/"
     schedule:


### PR DESCRIPTION
Enables the two-group dependabot config (org-actions / third-party, minor+patch only — majors stay singleton PRs). This repo's auto-merge caller and generator are verified at Actions v0.9.0 (group-safe pipeline). Plan of record: Coalfire-CF/Actions#147 (DA-passed, canary scorecard attached there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)